### PR TITLE
Add s.f display format option

### DIFF
--- a/app/src/main/java/omegacentauri/mobi/simplestopwatch/MyChrono.java
+++ b/app/src/main/java/omegacentauri/mobi/simplestopwatch/MyChrono.java
@@ -235,6 +235,7 @@ public class MyChrono implements BigTextView.GetCenter, MyTimeKeeper {
             return String.format("\u2212%d", -floorDiv(t,1000));
         String format = options.getString(Options.PREF_FORMAT, "h:m:s");
         boolean fraction = format.endsWith(".ms");
+        boolean frames = format.endsWith(".f");
         String suffix;
         if (fraction) {
             format = format.substring(0, format.lastIndexOf('.'));
@@ -250,6 +251,10 @@ public class MyChrono implements BigTextView.GetCenter, MyTimeKeeper {
             else {
                 suffix = "";
             }
+        }
+        else if (frames) {
+            format = format.substring(0, format.lastIndexOf('.'));
+            suffix = String.format(".%02d", (int)((t % 1000)*(24.0/1000.0)));
         }
         else {
             suffix = "";
@@ -303,7 +308,7 @@ public class MyChrono implements BigTextView.GetCenter, MyTimeKeeper {
             return "";
         String seconds;
         String format = options.getString(Options.PREF_FORMAT, "h:m:s");
-        if (format.endsWith(".ms"))
+        if (format.endsWith(".ms") || format.endsWith(".f"))
             return "";
         if (format.endsWith("m")) {
             seconds = (includeColonIfNeeded ? ":" : "") + String.format("%02d", (t/1000)%60);

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -65,6 +65,7 @@
         <item>m:s.ms</item>
         <item>s</item>
         <item>s.ms</item>
+        <item>s.f</item>
     </string-array>
 
     <string-array name="extraButtonHeightValues">


### PR DESCRIPTION
- Adds 24 frame per second time suffix option

Decided against adding configurable fps setting or even formats with minutes because I couldn't find evidence that use cases exist.  For animation timing, it's for pre-visualizing storyboard shots, thus minutes are too long.  Additionally, 24 fps seems like the dominant standard, and going beyond that opens a can of works for a huge number of (potentially non-integer) frame rates to support.